### PR TITLE
add bundles unload timeout

### DIFF
--- a/samples/router.ts
+++ b/samples/router.ts
@@ -25,11 +25,6 @@ export default new Router({
       component: Demo,
       name: "demo",
       path: "/demo"
-    },
-    {
-      component: GettingStarted,
-      name: "getting-started",
-      path: "/getting-started"
     }
   ]
 });

--- a/samples/views/Demo.vue
+++ b/samples/views/Demo.vue
@@ -24,13 +24,15 @@
       <three>
         <renderer :canvas="canvas" :camera="activeCamera" :scene="activeScene" antialias shadows/>
 
-        <asset-bundle name="PolygonMini" preload>
+        <asset-bundle name="PolygonMini" preload :timeout="30000">
           <texture name="PolygonMini_Tex" src="/assets/textures/PolygonMinis_Texture_01.png"/>
 
           <standard-material name="PolygonMini_Mat" map="PolygonMini_Tex"/>
 
           <model name="PM_column" src="/assets/models/SM_Tile_Hex_Column_02.fbx" materials="PolygonMini_Mat"/>
           <model name="PM_flat" src="/assets/models/SM_Tile_Hex_Flat_01.fbx" materials="PolygonMini_Mat"/>
+
+          <Model name="Mixamo_YBot" src="/assets/models/ybot.fbx"/>
         </asset-bundle>
 
         <asset-bundle name="Forms">

--- a/src/components/AssetBundle.ts
+++ b/src/components/AssetBundle.ts
@@ -13,6 +13,9 @@ export class AssetBundle extends Mixins(AppComponent) {
   @Prop({ type: Boolean, default: false })
   public preload!: boolean;
 
+  @Prop({ type: Number, default: 0 })
+  public timeout!: number;
+
   @Prop({ type: [String, Array], default: () => [] })
   public dependencies!: string | string[];
 
@@ -31,6 +34,7 @@ export class AssetBundle extends Mixins(AppComponent) {
     this.m_bundle.onLoad.on(this.onLoad);
     this.m_bundle.onUnload.on(this.onUnload);
     this.m_bundle.preload = this.preload;
+    this.m_bundle.unloadTimeout = this.timeout;
 
     Provider.setValue(this.provideBundle, this.m_bundle);
   }


### PR DESCRIPTION
Minor changes:
- Add unload timeout to avoid unloading/reloading the same assets when changing scenes in a short time

Patchs:
- Fix bundle preload: only asset bundles with the `preload` property will be preloaded (all asset bundles were preloaded previously)